### PR TITLE
Let EditorialStatus written into CSV by adding the fieldToCsv function in BulkMapping in BulkAd

### DIFF
--- a/src/main/java/com/microsoft/bingads/bulk/entities/BulkAd.java
+++ b/src/main/java/com/microsoft/bingads/bulk/entities/BulkAd.java
@@ -124,6 +124,12 @@ class BulkAd<T extends Ad> extends SingleRecordBulkEntity {
         ));
 
         m.add(new SimpleBulkMapping<BulkAd, String>(StringTable.EditorialStatus,
+                new Function<BulkAd, String>() {
+                    @Override
+                    public String apply(BulkAd bulkAd) {
+                        return bulkAd.getAd().getEditorialStatus().value();
+                    }
+                },
                 new BiConsumer<String, BulkAd>() {
                     @Override
                     public void accept(String v, BulkAd c) {


### PR DESCRIPTION
When we use BulkFileReader to read a TextAd in csv file which was written by BulkFileWritter, we found that EditorialStatus could not be got, but this status is meaningful for us to use. 

So we create a pull request.